### PR TITLE
Feature/#12 회원 가입시 추가 설정 기능 구현

### DIFF
--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/image/application/FileService.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/image/application/FileService.java
@@ -1,0 +1,44 @@
+package com.loginStudy.oauth2andJwt.domain.image.application;
+
+import com.loginStudy.oauth2andJwt.domain.image.dto.FileDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class FileService {
+    @Value("${file.dir}")
+    private String UPLOAD_DIR;
+
+    // 파일 업로드 메서드
+    public FileDto uploadFile(MultipartFile file) throws IOException {
+        String originalFilename = file.getOriginalFilename();
+        String storeFileName = createStoreFileName(originalFilename);
+
+        // 실제 파일 저장
+        String filePath = UPLOAD_DIR + storeFileName;
+        log.info("UPLOAD_DIR = {} " , UPLOAD_DIR);
+        File destinationFile = new File(filePath);
+        file.transferTo(destinationFile);
+
+        // FileDto로 반환
+        return new FileDto(originalFilename, storeFileName, filePath);
+    }
+
+    private String createStoreFileName(String originalFilename) {
+        String ext = extractExt(originalFilename);
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "." + ext;
+    }
+
+    private String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(pos + 1);
+    }
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/image/application/ImageService.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/image/application/ImageService.java
@@ -1,0 +1,31 @@
+package com.loginStudy.oauth2andJwt.domain.image.application;
+
+import com.loginStudy.oauth2andJwt.domain.image.dao.ImageRepository;
+import com.loginStudy.oauth2andJwt.domain.image.dto.FileDto;
+import com.loginStudy.oauth2andJwt.domain.image.entity.Image;
+import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final FileService fileService;
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public Image saveImage(MultipartFile file, Member member) throws IOException {
+        // 파일 저장 및 파일 경로, 파일명 설정
+        FileDto fileDto = fileService.uploadFile(file);
+
+        // 이미지 엔티티 생성 및 저장
+        Image image = fileDto.toImage(member);
+
+        return imageRepository.save(image);
+    }
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/image/dao/ImageRepository.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/image/dao/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.loginStudy.oauth2andJwt.domain.image.dao;
+
+import com.loginStudy.oauth2andJwt.domain.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/image/dto/FileDto.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/image/dto/FileDto.java
@@ -1,0 +1,23 @@
+package com.loginStudy.oauth2andJwt.domain.image.dto;
+
+import com.loginStudy.oauth2andJwt.domain.image.entity.Image;
+import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FileDto {
+    private String uploadFileName; // 업로드한 원본 파일명
+    private String storeFileName; // 서버에 저장된 파일명
+    private String filePath; // 파일의 전체 경로
+
+    public Image toImage(Member member) {
+        return Image.builder()
+                .uploadFileName(this.uploadFileName)
+                .storeFileName(this.storeFileName)
+                .filePath(this.filePath)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/image/entity/Image.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/image/entity/Image.java
@@ -1,0 +1,56 @@
+package com.loginStudy.oauth2andJwt.domain.image.entity;
+
+import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "image")
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id", nullable = false)
+    private Long id;
+
+    // 원본 파일명 (사용자가 업로드한 파일명)
+    @Column(name = "upload_file_name", nullable = false)
+    private String uploadFileName;
+
+    // 서버에 저장된 파일명 (UUID 등으로 관리)
+    @Column(name = "store_file_name", nullable = false)
+    private String storeFileName;
+
+    // 파일 경로
+    @Column(name = "file_path", nullable = false)
+    private String filePath;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @Builder
+    public Image(Long id, String uploadFileName, String storeFileName, String filePath, Member member) {
+        this.id = id;
+        this.uploadFileName = uploadFileName;
+        this.storeFileName = storeFileName;
+        this.filePath = filePath;
+        this.member = member;
+    }
+
+    // 파일명을 포함한 전체 경로 생성
+    public String getFullPath() {
+        return filePath + storeFileName;
+    }
+
+    // 파일 정보 업데이트
+    public void updateImage(String uploadFileName, String storeFileName, String filePath) {
+        this.uploadFileName = uploadFileName;
+        this.storeFileName = storeFileName;
+        this.filePath = filePath;
+    }
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/image/entity/Image.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/image/entity/Image.java
@@ -42,11 +42,6 @@ public class Image {
         this.member = member;
     }
 
-    // 파일명을 포함한 전체 경로 생성
-    public String getFullPath() {
-        return filePath + storeFileName;
-    }
-
     // 파일 정보 업데이트
     public void updateImage(String uploadFileName, String storeFileName, String filePath) {
         this.uploadFileName = uploadFileName;

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/api/MemberController.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/api/MemberController.java
@@ -1,0 +1,27 @@
+package com.loginStudy.oauth2andJwt.domain.member.api;
+
+import com.loginStudy.oauth2andJwt.domain.member.application.MemberService;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberAdditionalSetupReqDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 추가 설정 API
+    @PostMapping("/{account}/additional-setup")
+    public ResponseEntity<String> additionalSetup(
+            @PathVariable String account,
+            @ModelAttribute MemberAdditionalSetupReqDto setupDto
+    ) throws IOException {
+        memberService.setupProfile(account, setupDto);
+        return ResponseEntity.ok("추가 설정이 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/api/MemberController.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/api/MemberController.java
@@ -1,13 +1,17 @@
 package com.loginStudy.oauth2andJwt.domain.member.api;
 
 import com.loginStudy.oauth2andJwt.domain.member.application.MemberService;
+import com.loginStudy.oauth2andJwt.domain.member.dto.rep.MemberProfileRepDto;
 import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberAdditionalSetupReqDto;
+import com.loginStudy.oauth2andJwt.global.auth.application.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/member")
 @RequiredArgsConstructor
@@ -23,5 +27,11 @@ public class MemberController {
     ) throws IOException {
         memberService.setupProfile(account, setupDto);
         return ResponseEntity.ok("추가 설정이 완료되었습니다.");
+    }
+    @GetMapping("/profile")
+    public ResponseEntity<MemberProfileRepDto> getMemberProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        String memberAccount = userDetails.getUsername();
+        MemberProfileRepDto profile = memberService.getMemberProfile(memberAccount);
+        return ResponseEntity.ok(profile);
     }
 }

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/application/MemberService.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/application/MemberService.java
@@ -1,0 +1,39 @@
+package com.loginStudy.oauth2andJwt.domain.member.application;
+
+import com.loginStudy.oauth2andJwt.domain.image.application.ImageService;
+import com.loginStudy.oauth2andJwt.domain.image.entity.Image;
+import com.loginStudy.oauth2andJwt.domain.member.dao.MemberRepository;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberAdditionalSetupReqDto;
+import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final ImageService imageService;
+
+    @Transactional
+    public void setupProfile(String memberAccount, MemberAdditionalSetupReqDto setupDto) throws IOException {
+        Member member = memberRepository.findByAccount(memberAccount)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
+
+        // 닉네임 설정 및 일반 회원으로 변경
+        member.updateNicknameAndRole(setupDto.getNickname());
+
+        // 프로필 이미지 저장 및 설정
+        MultipartFile profileImage = setupDto.getProfileImage();
+        if (profileImage != null && !profileImage.isEmpty()) {
+            Image image = imageService.saveImage(profileImage, member);
+            member.updateProfileImage(image); // Member에 프로필 이미지 설정
+        }
+
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/application/MemberService.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/application/MemberService.java
@@ -3,21 +3,24 @@ package com.loginStudy.oauth2andJwt.domain.member.application;
 import com.loginStudy.oauth2andJwt.domain.image.application.ImageService;
 import com.loginStudy.oauth2andJwt.domain.image.entity.Image;
 import com.loginStudy.oauth2andJwt.domain.member.dao.MemberRepository;
+import com.loginStudy.oauth2andJwt.domain.member.dto.rep.MemberProfileRepDto;
 import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberAdditionalSetupReqDto;
 import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final ImageService imageService;
+    private static final String FILE_PATH = "/images/";
 
     @Transactional
     public void setupProfile(String memberAccount, MemberAdditionalSetupReqDto setupDto) throws IOException {
@@ -35,5 +38,14 @@ public class MemberService {
         }
 
         memberRepository.save(member);
+    }
+    public MemberProfileRepDto getMemberProfile(String memberAccount) {
+        Member member = memberRepository.findByAccount(memberAccount)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
+
+        Image profileImage = member.getProfileImage();
+        String profileImageUrl = (profileImage != null) ? FILE_PATH + profileImage.getStoreFileName() : null;
+
+        return new MemberProfileRepDto(member.getNickname(), profileImageUrl);
     }
 }

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/rep/MemberProfileRepDto.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/rep/MemberProfileRepDto.java
@@ -1,0 +1,11 @@
+package com.loginStudy.oauth2andJwt.domain.member.dto.rep;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberProfileRepDto {
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/req/MemberAdditionalSetupReqDto.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/req/MemberAdditionalSetupReqDto.java
@@ -1,0 +1,12 @@
+package com.loginStudy.oauth2andJwt.domain.member.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+public class MemberAdditionalSetupReqDto {
+    private String nickname;
+    private MultipartFile profileImage;
+}

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/req/MemberLoginReqDto.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/req/MemberLoginReqDto.java
@@ -1,4 +1,4 @@
-package com.loginStudy.oauth2andJwt.domain.member.dto;
+package com.loginStudy.oauth2andJwt.domain.member.dto.req;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/req/MemberSignUpReqDto.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/dto/req/MemberSignUpReqDto.java
@@ -1,4 +1,4 @@
-package com.loginStudy.oauth2andJwt.domain.member.dto;
+package com.loginStudy.oauth2andJwt.domain.member.dto.req;
 
 import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
 import com.loginStudy.oauth2andJwt.domain.member.entity.Role;

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/entity/Member.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/entity/Member.java
@@ -3,13 +3,9 @@ package com.loginStudy.oauth2andJwt.domain.member.entity;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.loginStudy.oauth2andJwt.domain.image.entity.Image;
 import com.loginStudy.oauth2andJwt.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,6 +42,14 @@ public class Member extends BaseEntity {
     // 소셜 로그인 제공자 정보 (예: kakao, naver 등)
     @Column(name = "provider")
     private String provider;
+
+    // 닉네임
+    @Column(name = "nickname")
+    private String nickname;
+
+    // 프로필 이미지
+    @OneToOne(mappedBy = "member",fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private Image profileImage;
 
 
     @Builder

--- a/src/main/java/com/loginStudy/oauth2andJwt/domain/member/entity/Member.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/domain/member/entity/Member.java
@@ -71,4 +71,13 @@ public class Member extends BaseEntity {
                 .provider(provider)
                 .build();
     }
+
+    public void updateNicknameAndRole(String nickname) {
+        this.nickname = nickname;
+        this.role = Role.USER;
+    }
+
+    public void updateProfileImage(Image image) {
+        this.profileImage = image;
+    }
 }

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/auth/api/AuthController.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/auth/api/AuthController.java
@@ -1,7 +1,7 @@
 package com.loginStudy.oauth2andJwt.global.auth.api;
 
-import com.loginStudy.oauth2andJwt.domain.member.dto.MemberLoginReqDto;
-import com.loginStudy.oauth2andJwt.domain.member.dto.MemberSignUpReqDto;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberLoginReqDto;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberSignUpReqDto;
 import com.loginStudy.oauth2andJwt.global.auth.application.AuthService;
 import com.loginStudy.oauth2andJwt.global.dto.request.RefreshTokenRequestDto;
 import com.loginStudy.oauth2andJwt.global.dto.response.ApiResDto;

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/auth/api/AuthController.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/auth/api/AuthController.java
@@ -12,8 +12,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
 
-import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -69,6 +72,23 @@ public class AuthController {
         AuthResponseDto authResponseDto = authService.refreshAccessToken(refreshTokenRequestDto.getRefreshToken());
         return ResponseEntity.status(OK)
                 .body(ApiResDto.toSuccessForm(authResponseDto));
+    }
+    /**
+     * 임시 토큰을 검증하고 최종 액세스 및 리프레시 토큰 발급
+     */
+    @GetMapping("/issue-final-token")
+    public ResponseEntity<ApiResDto> issueFinalTokens(
+            @RequestParam("tempToken") String tempToken
+    ) {
+        AuthResponseDto authResponse = authService.retrieveAuthResponse(tempToken);
+
+        if (authResponse == null) {
+            return ResponseEntity.status(BAD_REQUEST)
+                    .body(ApiResDto.toFailForm(null));
+        }
+
+        return ResponseEntity.status(OK)
+                .body(ApiResDto.toSuccessForm(authResponse));
     }
 
     /**

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/AuthService.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/AuthService.java
@@ -82,4 +82,15 @@ public class AuthService {
         }
     }
 
+    /**
+     * 임시 토큰을 사용하여 Redis에서 인증 응답 데이터를 조회합니다.
+     *
+     * @param tempToken 임시 토큰 (프론트엔드에서 받은 tempToken)
+     * @return AuthResponseDto 인증에 필요한 Access, Refresh 토큰
+     *         조회된 데이터가 없을 경우 null을 반환합니다.
+     */
+    public AuthResponseDto retrieveAuthResponse(String tempToken) {
+        return redisTokenStore.retrieveAuthResponse(tempToken);
+    }
+
 }

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/AuthService.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/AuthService.java
@@ -1,8 +1,8 @@
 package com.loginStudy.oauth2andJwt.global.auth.application;
 
 import com.loginStudy.oauth2andJwt.domain.member.dao.MemberRepository;
-import com.loginStudy.oauth2andJwt.domain.member.dto.MemberLoginReqDto;
-import com.loginStudy.oauth2andJwt.domain.member.dto.MemberSignUpReqDto;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberLoginReqDto;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberSignUpReqDto;
 import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
 import com.loginStudy.oauth2andJwt.global.auth.application.security.JwtTokenProvider;
 import com.loginStudy.oauth2andJwt.global.auth.application.security.RedisTokenStore;

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/security/CustomOauth2LoginSuccessHandler.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/security/CustomOauth2LoginSuccessHandler.java
@@ -1,56 +1,45 @@
 package com.loginStudy.oauth2andJwt.global.auth.application.security;
 
 import com.loginStudy.oauth2andJwt.global.dto.response.AuthResponseDto;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class CustomOauth2LoginSuccessHandler implements AuthenticationSuccessHandler {
-    private final JwtTokenProvider jwtTokenProvider;
 
-    // 상수로 선언
-    private static final String ACCESS_TOKEN_NAME = "accessToken";
-    private static final String REFRESH_TOKEN_NAME = "refreshToken";
-    private static final String SIGN_UP_URL = "http://localhost:3000/signUp/setUp";
-    private static final String SIGN_UP_URL_PATTERN = "%s?account=%s"; // URL 패턴 상수
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTokenStore redisTokenStore;
+    private static final String TEMP_TOKEN_NAME = "tempToken";
+    private static final String GUEST = "isGuest";
+    private static final String USER_ACCOUNT = "account";
     private static final String SUCCESS_URL = "http://localhost:3000/success-page";
-    private static final int TOKEN_EXPIRATION = 300;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        // createAuthResponse 호출하여 AuthResponseDto 생성
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
+
+        // 최종 액세스 및 리프레시 토큰 생성
         AuthResponseDto authResponse = jwtTokenProvider.createAuthResponse(authentication);
 
-        // 쿠키 설정 메소드 호출 (만료 시간을 5분으로 설정)
-        setTokenCookie(response, ACCESS_TOKEN_NAME, authResponse.getAccessToken());
-        setTokenCookie(response, REFRESH_TOKEN_NAME, authResponse.getRefreshToken());
+        // Redis에 authResponse 저장 및 임시 토큰 발급
+        String tempToken = redisTokenStore.generateTemporaryToken(authResponse);
+        String account = oAuth2User.getAccount();
+        boolean isGuest = oAuth2User.isGuest();
+        // 성공 URL에 쿼리 파라미터로 임시 토큰과 isGuest 정보를 전달
+        String redirectUrl = UriComponentsBuilder.fromUriString(SUCCESS_URL)
+                .queryParam(TEMP_TOKEN_NAME, tempToken)
+                .queryParam(GUEST, isGuest)
+                .queryParam(USER_ACCOUNT, account)
+                .build().toUriString();
 
-        CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
-        // 처음 로그인 한 회원의 경우 추가 설정으로 리다이렉트
-        if (oAuth2User.isGuest()) {
-            // GUEST 역할: 추가 설정 페이지로 리다이렉트
-            String redirectUrl = String.format(SIGN_UP_URL_PATTERN, SIGN_UP_URL, oAuth2User.getUsername());
-            response.sendRedirect(redirectUrl);
-        } else {
-            response.sendRedirect(SUCCESS_URL);
-        }
-    }
-
-    private void setTokenCookie(HttpServletResponse response, String name, String token) {
-        Cookie cookie = new Cookie(name, token);
-        cookie.setSecure(false);  // HTTPS 환경에서는 true로 설정
-        cookie.setPath("/");
-        cookie.setMaxAge(TOKEN_EXPIRATION);
-        //        cookie.setHttpOnly(true); -> 프론트에서 로컬 스토리지에 저장하지 않고, 쿠키로만 토큰을 주고 받는 경우
-        response.addCookie(cookie);
+        response.sendRedirect(redirectUrl); // 프론트엔드로 리다이렉트
     }
 }
 

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/security/CustomOauth2LoginSuccessHandler.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/auth/application/security/CustomOauth2LoginSuccessHandler.java
@@ -20,6 +20,7 @@ public class CustomOauth2LoginSuccessHandler implements AuthenticationSuccessHan
     private static final String ACCESS_TOKEN_NAME = "accessToken";
     private static final String REFRESH_TOKEN_NAME = "refreshToken";
     private static final String SIGN_UP_URL = "http://localhost:3000/signUp/setUp";
+    private static final String SIGN_UP_URL_PATTERN = "%s?account=%s"; // URL 패턴 상수
     private static final String SUCCESS_URL = "http://localhost:3000/success-page";
     private static final int TOKEN_EXPIRATION = 300;
 
@@ -35,7 +36,9 @@ public class CustomOauth2LoginSuccessHandler implements AuthenticationSuccessHan
         CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
         // 처음 로그인 한 회원의 경우 추가 설정으로 리다이렉트
         if (oAuth2User.isGuest()) {
-            response.sendRedirect(SIGN_UP_URL);
+            // GUEST 역할: 추가 설정 페이지로 리다이렉트
+            String redirectUrl = String.format(SIGN_UP_URL_PATTERN, SIGN_UP_URL, oAuth2User.getUsername());
+            response.sendRedirect(redirectUrl);
         } else {
             response.sendRedirect(SUCCESS_URL);
         }

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/config/RedisConfig.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/config/RedisConfig.java
@@ -18,6 +18,9 @@ public class RedisConfig {
         // 키를 문자열로 직렬화
         redisTemplate.setKeySerializer(new StringRedisSerializer());
 
+        // JSON 직렬화기 추가 설정
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
         // 해시 키를 문자열로 직렬화
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 

--- a/src/main/java/com/loginStudy/oauth2andJwt/global/config/WebConfig.java
+++ b/src/main/java/com/loginStudy/oauth2andJwt/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.loginStudy.oauth2andJwt.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Value("${file.dir}")
+    private String UPLOAD_DIR;
+    private static final String FILE_PATH = "/images/**";
+    private static final String FILE_PROTOCOL = "file:///";
+
+    /**
+     * 외부 URL 요청을 시스템의 지정된 경로에서 제공하도록 설정합니다.
+     * 예: /images/** 경로로 요청 시 실제 저장된 이미지 파일을 반환합니다.
+     */
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(FILE_PATH)
+                .addResourceLocations(FILE_PROTOCOL + UPLOAD_DIR); // 실제 이미지 저장 경로
+    }
+}

--- a/src/test/java/com/loginStudy/oauth2andJwt/global/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/loginStudy/oauth2andJwt/global/auth/application/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package com.loginStudy.oauth2andJwt.global.auth.application;
 
 import com.loginStudy.oauth2andJwt.domain.member.dao.MemberRepository;
-import com.loginStudy.oauth2andJwt.domain.member.dto.MemberSignUpReqDto;
+import com.loginStudy.oauth2andJwt.domain.member.dto.req.MemberSignUpReqDto;
 import com.loginStudy.oauth2andJwt.domain.member.entity.Member;
 import com.loginStudy.oauth2andJwt.global.error.BusinessException;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## 🔥 Related Issue
close: #12 
## 📝 Description
소셜 로그인으로 회원 정보 추가 설정 시 이미지 및 닉네임 저장 기능과
회원 프로필 조회 시, 이미지 및 닉네임 조회 기능도 구현하였습니다.
추가로 기존 클라이언트와 쿠키 방식으로 토큰을 전달하였는데, 임시 토큰을 발행하여 클라이언트에 전달하고, 
전달된 임시토큰으로 새로 요청하면 Access/Refresh Token을 받을 수 있도록 리펙토링 하였습니다.

## ⭐️ Review